### PR TITLE
Fixed Batch sample validation and test script

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -73,7 +73,9 @@ then
     fi
     echo `date +%Y%m%d-%H%M`,`basename $EXECUTABLE`,$BUILDTIME,$BUILDMEMORY,${RSS},${SIZE},${STIME},${JTIME}  > $SUMMARY_CSV_FILE
   fi
-  kill ${PID}
+  if ! kill ${PID} > /dev/null 2>&1; then
+    echo "Did not kill process, it ended on it's own" >&2
+  fi
   exit 0
 else
   cat $BUILD_OUTPUT_FILE
@@ -82,6 +84,8 @@ else
   if [ $SILENT == 'false' ]; then
     echo `date +%Y%m%d-%H%M`,`basename $EXECUTABLE`,ERROR,-,,,, > $SUMMARY_CSV_FILE
   fi
-  kill ${PID}
+  if ! kill ${PID} > /dev/null 2>&1; then
+    echo "Did not kill process, it ended on it's own" >&2
+  fi
   exit 1
 fi

--- a/spring-graal-native-samples/spring-batch/verify.sh
+++ b/spring-graal-native-samples/spring-batch/verify.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-if [[ `cat target/native-image/test-output.txt | grep "spring-batch running!"` ]]; then
+if [[ `cat target/native-image/test-output.txt | grep ">> This was run in a Spring Batch app!"` ]]; then
   exit 0
 else
   exit 1


### PR DESCRIPTION
This commit fixes what is validated that the batch application was run
successfully as well as updates test.sh to display a more user friendly
error message for killing a PID that has already finished.